### PR TITLE
Fix : 그룹별 활동 조회의 그룹 번호가 고유한 그룹 번호가 아니기에 tag로 변환 시켜줌(#65)

### DIFF
--- a/histudy-front/src/components/Manager/ReportTable.js
+++ b/histudy-front/src/components/Manager/ReportTable.js
@@ -47,7 +47,7 @@ export default function ReportTable({
           padding: "0 20px",
         }}
       >
-        <span>Group {data.group}</span>
+        <span>Group {data.tag}</span>
         {"   "}
         <span>
           {data.members.map((member, index) => (


### PR DESCRIPTION
## Description

그룹별 활동 조회의 그룹 번호가 고유한 그룹 번호가 아니기에 tag로 변환 시켜줌
group.group -> group.tag