### PR TITLE
Feat: 그룹 미배정 학생들의 그룹 박스를 크기를 고정 시켜서 관리자가 쉽게 수정할 수 있도록 한다 (#76)

### DIFF
--- a/histudy-front/src/components/Manager/GroupSelector.js
+++ b/histudy-front/src/components/Manager/GroupSelector.js
@@ -95,7 +95,7 @@ export default function GroupSelector({ team, setTeam }) {
       id="combo-box-demo"
       options={groupData} // groupAutoComplete 값을 사용하도록 수정했습니다.
       freeSolo
-      sx={{ width: 150 }}
+      sx={{ width: 120 }}
       renderInput={(params) => <TextField {...params} />}
     />
   );

--- a/histudy-front/src/components/Manager/UnGroupTable.js
+++ b/histudy-front/src/components/Manager/UnGroupTable.js
@@ -240,7 +240,6 @@ export default function UnGroupTable({
                       color: "text.secondary",
                       display: "flex",
                       flexGrow: 1,
-                      width: "80px",
                       marginLeft: "20px",
                       textOverflow: "ellipsis",
                       overflowX: "auto",


### PR DESCRIPTION
### Request Description

그룹 선택하는 콤보박스의 폭을 고정해줄 수 있을까요? 브라우저 창 폭을 줄여서 쓸 때가 있는데 그러면 콤보박스 폭도 줄어서 그룹번호가 다 안보일 때가 있습니다.

### 작업한 내용
[관리자 페이지] 그룹 매칭 관리 페이지 -> 그룹 미배정 학생 목록 -> 그룹 배정 콤보박스의 폭을 넓히고 (80 -> 120) 고정 한다.