### PR TITLE
[REQUEST] Feature : 관리자는 Rank 사진을 클릭하면 사진 원본을 볼 수 있다. (#77)

### DIFF
--- a/histudy-front/src/components/Rank/FullImage.js
+++ b/histudy-front/src/components/Rank/FullImage.js
@@ -8,7 +8,7 @@ const style = {
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
-  width: 400,
+  width: 600,
   bgcolor: "background.paper",
   border: "2px solid #000",
   boxShadow: 24,
@@ -20,7 +20,6 @@ function FullImageComponent({ fullImageUrl }) {
     useRecoilState(isShowFullImageState);
 
   const handleClose = () => setIsShowFullImage(false);
-  console.log("fullImageUrl", fullImageUrl);
   return (
     <Modal
       open={isShowFullImage}
@@ -29,13 +28,6 @@ function FullImageComponent({ fullImageUrl }) {
       aria-describedby="modal-modal-description"
     >
       <Box component="img" src={fullImageUrl} sx={style} />
-      {/* <Typography id="modal-modal-title" variant="h6" component="h2">
-          Text in a modal
-        </Typography>
-        <Typography id="modal-modal-description" sx={{ mt: 2 }}>
-          Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
-        </Typography>
-      </Box> */}
     </Modal>
   );
 }

--- a/histudy-front/src/components/Rank/FullImage.js
+++ b/histudy-front/src/components/Rank/FullImage.js
@@ -1,6 +1,7 @@
 import { Box, Modal, Typography } from "@mui/material";
 import { useRecoilState } from "recoil";
 import { isShowFullImageState } from "../../store/atom";
+import React from "react";
 
 const style = {
   position: "absolute",
@@ -14,7 +15,7 @@ const style = {
   p: 4,
 };
 
-export default function FullImage({ fullImageUrl }) {
+function FullImageComponent({ fullImageUrl }) {
   const [isShowFullImage, setIsShowFullImage] =
     useRecoilState(isShowFullImageState);
 
@@ -38,3 +39,7 @@ export default function FullImage({ fullImageUrl }) {
     </Modal>
   );
 }
+
+const FullImage = React.memo(FullImageComponent);
+
+export default FullImage;

--- a/histudy-front/src/components/Rank/FullImage.js
+++ b/histudy-front/src/components/Rank/FullImage.js
@@ -1,0 +1,40 @@
+import { Box, Modal, Typography } from "@mui/material";
+import { useRecoilState } from "recoil";
+import { isShowFullImageState } from "../../store/atom";
+
+const style = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: 400,
+  bgcolor: "background.paper",
+  border: "2px solid #000",
+  boxShadow: 24,
+  p: 4,
+};
+
+export default function FullImage({ fullImageUrl }) {
+  const [isShowFullImage, setIsShowFullImage] =
+    useRecoilState(isShowFullImageState);
+
+  const handleClose = () => setIsShowFullImage(false);
+  console.log("fullImageUrl", fullImageUrl);
+  return (
+    <Modal
+      open={isShowFullImage}
+      onClose={handleClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <Box component="img" src={fullImageUrl} sx={style} />
+      {/* <Typography id="modal-modal-title" variant="h6" component="h2">
+          Text in a modal
+        </Typography>
+        <Typography id="modal-modal-description" sx={{ mt: 2 }}>
+          Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
+        </Typography>
+      </Box> */}
+    </Modal>
+  );
+}

--- a/histudy-front/src/components/Rank/Item.js
+++ b/histudy-front/src/components/Rank/Item.js
@@ -4,7 +4,7 @@ import GroupsIcon from "@mui/icons-material/Groups";
 
 export default function Item({ item, itemsHover, index }) {
   return (
-    <ImageListItem key={item?.img} sx={{ position: "relative" }}>
+    <ImageListItem key={index} sx={{ position: "relative" }}>
       {!itemsHover[index] && (
         <motion.img
           key={index}

--- a/histudy-front/src/pages/Rank/Rank.js
+++ b/histudy-front/src/pages/Rank/Rank.js
@@ -13,6 +13,12 @@ import Title from "../../components/common/Title";
 import { useQuery } from "react-query";
 
 import Item from "../../components/Rank/Item";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import {
+  authorityState,
+  fullImageState,
+  isShowFullImageState,
+} from "../../store/atom";
 
 const StyledScrollBox = styled(Box)({
   maxWidth: "1245px",
@@ -53,6 +59,14 @@ export default function Rank() {
     ]);
   };
 
+  const setIsShowFullImage = useSetRecoilState(isShowFullImageState);
+  const myAuthority = useRecoilValue(authorityState);
+
+  const handleFullImageOpen = () => {
+    if (myAuthority !== "ADMIN") return;
+    setIsShowFullImage(true);
+  };
+
   return (
     <StyledColumnAlignLayout
       component={motion.div}
@@ -73,7 +87,7 @@ export default function Rank() {
             animate={{ opacity: 1, y: 0 }}
           >
             {teams.map((item, index) => (
-              <Grid item key={index}>
+              <Grid item key={index} onClick={handleFullImageOpen}>
                 <StyledItemSize
                   onMouseOver={() => handleMouseOver(index)}
                   onMouseOut={() => handleMouseOut(index)}

--- a/histudy-front/src/pages/Rank/Rank.js
+++ b/histudy-front/src/pages/Rank/Rank.js
@@ -68,8 +68,6 @@ export default function Rank() {
     if (myAuthority !== "ADMIN") return;
     if (!imageUrl) {
       setFullImageUrl("/img/mainImg2.png");
-
-      console.log(fullImageUrl);
     } else setFullImageUrl(imageUrl);
     setIsShowFullImage(true);
   };

--- a/histudy-front/src/pages/Rank/Rank.js
+++ b/histudy-front/src/pages/Rank/Rank.js
@@ -19,6 +19,7 @@ import {
   fullImageState,
   isShowFullImageState,
 } from "../../store/atom";
+import FullImage from "../../components/Rank/FullImage";
 
 const StyledScrollBox = styled(Box)({
   maxWidth: "1245px",
@@ -61,56 +62,69 @@ export default function Rank() {
 
   const setIsShowFullImage = useSetRecoilState(isShowFullImageState);
   const myAuthority = useRecoilValue(authorityState);
+  const [fullImageUrl, setFullImageUrl] = useState(null);
 
-  const handleFullImageOpen = () => {
+  const handleFullImageOpen = async (imageUrl) => {
     if (myAuthority !== "ADMIN") return;
+    if (!imageUrl) {
+      setFullImageUrl("/img/mainImg2.png");
+
+      console.log(fullImageUrl);
+    } else setFullImageUrl(imageUrl);
     setIsShowFullImage(true);
   };
 
   return (
-    <StyledColumnAlignLayout
-      component={motion.div}
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-    >
-      <Title text="스터디 그룹 랭킹" />
+    <>
+      <FullImage fullImageUrl={fullImageUrl} />
+      <StyledColumnAlignLayout
+        component={motion.div}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+      >
+        <Title text="스터디 그룹 랭킹" />
 
-      {teams.length === 0 ? (
-        <NoDataLottie />
-      ) : (
-        <StyledScrollBox>
-          <ImageList
-            cols={4}
-            gap={15}
-            component={motion.div}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-          >
-            {teams.map((item, index) => (
-              <Grid item key={index} onClick={handleFullImageOpen}>
-                <StyledItemSize
-                  onMouseOver={() => handleMouseOver(index)}
-                  onMouseOut={() => handleMouseOut(index)}
+        {teams.length === 0 ? (
+          <NoDataLottie />
+        ) : (
+          <StyledScrollBox>
+            <ImageList
+              cols={4}
+              gap={15}
+              component={motion.div}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
+              {teams.map((item, index) => (
+                <Grid
+                  item
+                  key={index}
+                  onClick={() => handleFullImageOpen(item?.thumbnail)}
                 >
-                  <AnimatePresence>
-                    {itemsHover[index] && (
-                      <HoverBox
-                        members={item.members}
-                        reports={item.reports}
-                        totalMinutes={item.totalMinutes}
-                      />
-                    )}
-                  </AnimatePresence>
+                  <StyledItemSize
+                    onMouseOver={() => handleMouseOver(index)}
+                    onMouseOut={() => handleMouseOut(index)}
+                  >
+                    <AnimatePresence>
+                      {itemsHover[index] && (
+                        <HoverBox
+                          members={item.members}
+                          reports={item.reports}
+                          totalMinutes={item.totalMinutes}
+                        />
+                      )}
+                    </AnimatePresence>
 
-                  <Item index={index} item={item} itemsHover={itemsHover} />
-                </StyledItemSize>
-              </Grid>
-            ))}
-          </ImageList>
-        </StyledScrollBox>
-      )}
+                    <Item index={index} item={item} itemsHover={itemsHover} />
+                  </StyledItemSize>
+                </Grid>
+              ))}
+            </ImageList>
+          </StyledScrollBox>
+        )}
 
-      {/* </Grid> */}
-    </StyledColumnAlignLayout>
+        {/* </Grid> */}
+      </StyledColumnAlignLayout>
+    </>
   );
 }

--- a/histudy-front/src/store/atom.js
+++ b/histudy-front/src/store/atom.js
@@ -60,3 +60,8 @@ export const authorityState = atom({
   default: "NONUSER",
   effects_UNSTABLE: [persistAtom],
 });
+
+export const isShowFullImageState = atom({
+  key: "isShowFullImage",
+  default: false,
+});


### PR DESCRIPTION
### Request Description
관리자는 Rank 사진을 클릭하면 사진 원본을 볼 수 있으면 좋습니다. 사진에 찍힌 학생들 확인이 필요할 때가 있어요.

### 작업한 사항

Rank 페이지에서도 `관리자만` 사진 원본을 관람할 수 있도록 기능을 추가하였다.
Rank에서 그룹을 클릭하면 그 그룹에 보이는 사진이 원본의 형태로 모달이 띄워진다.
이를 통해 `관리자`는 원본 사진을 통해 스터디 활동에 대한 정보를 얻을 수 있다.