### PR TITLE
[Request] FIX : 사진 보관함을 Firebase Storage에서 Isel 서버로 migrate 한다. (#82)

### DIFF
--- a/histudy-front/src/apis/rank.js
+++ b/histudy-front/src/apis/rank.js
@@ -5,3 +5,16 @@ export const getAllTeamsForRank = async () => {
   const response = await axiosInstance.get(`/api/public/teams`);
   return response;
 };
+
+export const ImageUploadApi = async (reportIdOr, formData) => {
+  const response = await axiosInstance.post(
+    `/api/team/reports/${reportIdOr}/image`,
+    formData,
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    }
+  );
+  return response;
+};

--- a/histudy-front/src/apis/rank.js
+++ b/histudy-front/src/apis/rank.js
@@ -7,12 +7,15 @@ export const getAllTeamsForRank = async () => {
 };
 
 export const ImageUploadApi = async (reportIdOr, formData) => {
-  const response = await axiosInstance.post(
-    `/api/team/reports/${reportIdOr}/image`,
+  const response = await axios.post(
+    `${process.env.REACT_APP_BACK_BASE_URL}/api/team/reports${
+      reportIdOr === null ? "" : `/${reportIdOr}`
+    }/image`,
     formData,
     {
       headers: {
         "Content-Type": "multipart/form-data",
+        Authorization: "Bearer " + localStorage.getItem("accessToken"),
       },
     }
   );

--- a/histudy-front/src/components/Image/PreviewImage.js
+++ b/histudy-front/src/components/Image/PreviewImage.js
@@ -1,0 +1,45 @@
+import { IconButton, ImageListItem } from "@mui/material";
+import ClearIcon from "@mui/icons-material/Clear";
+
+export default function PreviewImage({ getValues, setValue, state }) {
+  return (
+    <>
+      {getValues(state)?.map((imageUrl, index) => (
+        <ImageListItem
+          sx={{
+            position: "relative",
+            mt: "20px",
+            mr: "20px",
+            maxWidth: "450px",
+            maxHeight: "450px",
+          }}
+          key={index}
+        >
+          <img src={imageUrl} loading="lazy" alt={imageUrl} />
+          <IconButton
+            onClick={() => {
+              const prev = getValues(state);
+              setValue(state, [
+                ...prev.slice(0, index),
+                ...prev.slice(index + 1),
+              ]);
+              state === "previewImages" &&
+                setValue("blobImages", [
+                  ...prev.slice(0, index),
+                  ...prev.slice(index + 1),
+                ]);
+            }}
+            sx={{
+              position: "absolute",
+              right: "0",
+              color: "black",
+            }}
+            aria-label={`star`}
+          >
+            <ClearIcon />
+          </IconButton>
+        </ImageListItem>
+      ))}
+    </>
+  );
+}

--- a/histudy-front/src/components/Image/UploadImage.js
+++ b/histudy-front/src/components/Image/UploadImage.js
@@ -106,7 +106,13 @@ export function ImageUpload({ setValue, getValues }) {
         <ImageList sx={{ width: "1000px" }} cols={2}>
           {getValues("images")?.map((imageUrl, index) => (
             <ImageListItem
-              sx={{ position: "relative", mt: "20px", mr: "20px" }}
+              sx={{
+                position: "relative",
+                mt: "20px",
+                mr: "20px",
+                maxWidth: "450px",
+                maxHeight: "450px",
+              }}
               key={index}
             >
               <img src={imageUrl} loading="lazy" alt={imageUrl} />

--- a/histudy-front/src/components/Image/UploadImageToServer.js
+++ b/histudy-front/src/components/Image/UploadImageToServer.js
@@ -1,26 +1,16 @@
 import { useCallback, useRef, useState } from "react";
-import {
-  ref,
-  getDownloadURL,
-  uploadBytes,
-  uploadBytesResumable,
-} from "firebase/storage";
-import { getValue } from "@testing-library/user-event/dist/utils";
-import { storage } from "../../Firebase/firebase";
 
-import {
-  Box,
-  Button,
-  IconButton,
-  ImageList,
-  ImageListItem,
-  ImageListItemBar,
-} from "@mui/material";
-import StarBorderIcon from "@mui/icons-material/StarBorder";
-import { importCourses } from "../../apis/course";
+import { Box, Button, ImageList } from "@mui/material";
 import Heic2Jpg from "./Heic2Jpg";
 import compressedFile from "./compressFile";
 import PreviewImage from "./PreviewImage";
+
+function blobToFile(blob, fileName) {
+  return new File([blob], fileName, {
+    type: blob.type,
+    lastModified: new Date().getTime(),
+  });
+}
 
 export function ImageUploadToServer({ setValue, getValues }) {
   const [previewUrl, setPreviewUrl] = useState(null);
@@ -49,7 +39,10 @@ export function ImageUploadToServer({ setValue, getValues }) {
     };
     reader.readAsDataURL(file[0]);
 
-    setValue("blobImages", [...getValues("blobImages"), lowCapacityFile]);
+    setValue("blobImages", [
+      ...getValues("blobImages"),
+      blobToFile(lowCapacityFile, "test.jpg"),
+    ]);
   };
 
   return (

--- a/histudy-front/src/components/Image/UploadImageToServer.js
+++ b/histudy-front/src/components/Image/UploadImageToServer.js
@@ -1,0 +1,96 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  ref,
+  getDownloadURL,
+  uploadBytes,
+  uploadBytesResumable,
+} from "firebase/storage";
+import { getValue } from "@testing-library/user-event/dist/utils";
+import { storage } from "../../Firebase/firebase";
+
+import {
+  Box,
+  Button,
+  IconButton,
+  ImageList,
+  ImageListItem,
+  ImageListItemBar,
+} from "@mui/material";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
+import { importCourses } from "../../apis/course";
+import Heic2Jpg from "./Heic2Jpg";
+import compressedFile from "./compressFile";
+import PreviewImage from "./PreviewImage";
+
+export function ImageUploadToServer({ setValue, getValues }) {
+  const [previewUrl, setPreviewUrl] = useState(null);
+
+  const inputRef = useRef(null);
+  const onUploadImageButtonClick = useCallback(() => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    inputRef.current.click();
+  }, []);
+
+  const onImageChange = async (e) => {
+    e.preventDefault();
+    const file = e.target.files;
+    if (!file) return null;
+
+    const convertedFile = await Heic2Jpg(file[0]);
+
+    const lowCapacityFile = await compressedFile(convertedFile);
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setValue("previewImages", [...getValues("previewImages"), reader.result]);
+    };
+    reader.readAsDataURL(file[0]);
+
+    setValue("blobImages", [...getValues("blobImages"), lowCapacityFile]);
+  };
+
+  return (
+    <>
+      <Button
+        onClick={onUploadImageButtonClick}
+        variant="outlined"
+        sx={{
+          backgroundColor: "background.default",
+          borderColor: "primary.main",
+          color: "primary.main",
+          fontWeight: "normal",
+          mt: "20px",
+        }}
+      >
+        인증샷 업로드
+      </Button>
+
+      {previewUrl && <img src={previewUrl} alt="Preview" />}
+      <input
+        hidden
+        type="file"
+        // accept="image/*"
+        accept=".jpg,.jpeg,.png,.gif,.bmp,.heic,.heif"
+        ref={inputRef}
+        onChange={onImageChange}
+      />
+      <Box sx={{ display: "flex" }}>
+        <ImageList sx={{ width: "1000px" }} cols={2}>
+          <PreviewImage
+            getValues={getValues}
+            setValue={setValue}
+            state="images"
+          />
+          <PreviewImage
+            getValues={getValues}
+            setValue={setValue}
+            state="previewImages"
+          />
+        </ImageList>
+      </Box>
+    </>
+  );
+}

--- a/histudy-front/src/pages/Post/Post.js
+++ b/histudy-front/src/pages/Post/Post.js
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   FormControl,
   InputLabel,
   MenuItem,
@@ -54,14 +53,13 @@ export default function Post({ children }) {
 
   const navigate = useNavigate();
 
-  const onValid = (formData) => {
-    console.log(formData);
+  const onValid = async (formData) => {
     for (let i = 0; i < formData.blobImages.length; ++i) {
       const imageForm = new FormData();
       imageForm.append("image", formData.blobImages[i]);
-      ImageUploadApi(state ? state.id : null, imageForm).then((res) => {
-        console.log(res);
-        setValue("images", [...formData.images, res.data.imagePath]);
+
+      await ImageUploadApi(state ? state.id : null, imageForm).then((res) => {
+        setValue("images", [...getValues("images"), res.data?.imagePath]);
       });
     }
 
@@ -71,7 +69,7 @@ export default function Post({ children }) {
       content: formData.content,
       totalMinutes: Number(formData.totalMinutes),
       participants: formData.participants,
-      images: formData.images,
+      images: getValues("images"),
       courses: formData.courses,
     };
     state ? modifyReport(state.id, newReport) : postReport(newReport);
@@ -106,7 +104,6 @@ export default function Post({ children }) {
               fontColor="white"
             />
           </Box>
-          {/* <ImageUpload setValue={setValue} getValues={getValues} /> */}
           <ImageUploadToServer setValue={setValue} getValues={getValues} />
         </PostBox>
 

--- a/histudy-front/src/pages/Post/Post.js
+++ b/histudy-front/src/pages/Post/Post.js
@@ -28,9 +28,12 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import Title from "../../components/common/Title";
 import { StyledColumnAlignLayout } from "../../components/common/StyledLayout";
+import { ImageUploadToServer } from "../../components/Image/UploadImageToServer";
+import { ImageUploadApi } from "../../apis/rank";
 
 export default function Post({ children }) {
   const { state } = useLocation();
+  console.log(state);
 
   const [isCodeModal, setIsCodeModal] = useState(false);
 
@@ -42,14 +45,26 @@ export default function Post({ children }) {
       totalMinutes: state ? state.totalMinutes : "",
       images: state ? [...state.images.map((image) => image.url)] : [],
       courses: state ? state.courses.map((c) => c.id.toString()) : [],
+      previewImages: [],
+      blobImages: [],
     },
   });
 
-  watch(["totalMinutes", "startTime", "endTime", "images"]);
+  watch(["totalMinutes", "startTime", "endTime", "images", "previewImages"]);
 
   const navigate = useNavigate();
 
   const onValid = (formData) => {
+    console.log(formData);
+    for (let i = 0; i < formData.blobImages.length; ++i) {
+      const imageForm = new FormData();
+      imageForm.append("image", formData.blobImages[i]);
+      ImageUploadApi(state ? state.id : null, imageForm).then((res) => {
+        console.log(res);
+        setValue("images", [...formData.images, res.data.imagePath]);
+      });
+    }
+
     // 보고서 생성 api 연결
     const newReport = {
       title: formData.title,
@@ -91,7 +106,8 @@ export default function Post({ children }) {
               fontColor="white"
             />
           </Box>
-          <ImageUpload setValue={setValue} getValues={getValues} />
+          {/* <ImageUpload setValue={setValue} getValues={getValues} /> */}
+          <ImageUploadToServer setValue={setValue} getValues={getValues} />
         </PostBox>
 
         <PostBox>


### PR DESCRIPTION
## Request Description

관리자는 사진을 직접 서버에서 관리하기 원한다.
요청 사항에 따라서 현재 Firebase Storage에 업로드 되고 있는 사진을 Isel 서버로 업로드 되도록 migrate한다.

## 변경된 사항

이미지 업로드 시 파일 미리 보기를 지원한다.
이미지를 압축한다.
레포트 생성/수정 이전에 먼저 이미지를 백엔드로 보내고 이미지를 먼저 저장한다.
저장된 이미지 경로를 레포트 생성/수정에 추가하여 백엔드에 보낸다.


Firebase Storage -> Isel 서버로 이동