### PR TITLE
[REQUEST] FEATURE : 관리자는 신청자 목록에서 학생들 이메일 주소를 관람할 수 있다. #78

### DIFF
--- a/histudy-front/src/components/Manager/CreateGroupTable.js
+++ b/histudy-front/src/components/Manager/CreateGroupTable.js
@@ -21,6 +21,7 @@ export default function CreateGroupTable({
   const TableHead = {
     all: [
       "이름",
+      "이메일",
       "학번",
       "희망 1과목",
       "희망 2과목",
@@ -105,7 +106,6 @@ export default function CreateGroupTable({
               >
                 {row.name}
               </Box>
-
               <Box
                 sx={{
                   color: "text.secondary",
@@ -113,6 +113,22 @@ export default function CreateGroupTable({
                   flexGrow: 1,
                   // width: "50px",
                   marginLeft: "70px",
+                  textOverflow: "ellipsis",
+                  overflowX: "auto",
+                  whiteSpace: "nowrap",
+                  py: "20px",
+                  borderColor: "primary.border",
+                }}
+              >
+                {row.email}
+              </Box>
+              <Box
+                sx={{
+                  color: "text.secondary",
+                  display: "flex",
+                  flexGrow: 1,
+                  // width: "50px",
+                  marginLeft: "20px",
                   textOverflow: "ellipsis",
                   overflowX: "auto",
                   whiteSpace: "nowrap",
@@ -147,7 +163,7 @@ export default function CreateGroupTable({
                 {row.courses.map((subject, index) => (
                   <Typography
                     sx={{
-                      minWidth: "150px",
+                      minWidth: "80px",
                     }}
                   >
                     {subject.name} ({subject.prof})
@@ -156,7 +172,7 @@ export default function CreateGroupTable({
                 {fillThree(row.courses.length).map((subject, index) => (
                   <Typography
                     sx={{
-                      minWidth: "150px",
+                      minWidth: "80px",
                     }}
                   >
                     {subject}
@@ -170,6 +186,7 @@ export default function CreateGroupTable({
                   display: "flex",
                   flexGrow: 1,
                   py: "20px",
+                  ml: "10px",
                   borderColor: "primary.border",
                 }}
               >

--- a/histudy-front/src/components/Manager/CreateGroupTable.js
+++ b/histudy-front/src/components/Manager/CreateGroupTable.js
@@ -20,13 +20,12 @@ export default function CreateGroupTable({
   };
   const TableHead = {
     all: [
-      "이름",
-      "이메일",
-      "학번",
+      "학생 정보",
       "희망 1과목",
       "희망 2과목",
       "희망 3과목",
       "함께하고 싶은 친구",
+      "삭제",
     ],
   };
 
@@ -54,6 +53,7 @@ export default function CreateGroupTable({
           sx={{
             color: "text.secondary",
             display: "flex",
+            justifyContent: "space-between",
             py: "20px",
 
             borderColor: "primary.main",
@@ -63,11 +63,13 @@ export default function CreateGroupTable({
           {TableHead[type].map((headElement, index) => (
             <Typography
               key={index}
-              sx={{
-                flexGrow: 1,
-                width: longWidthColumnNum === index + 1 && "50%",
-                minWidth: longWidthColumnNum !== index + 1 && "150px",
-              }}
+              sx={
+                {
+                  // flexGrow: 1,
+                  // width: longWidthColumnNum === index + 1 && "50%",
+                  // minWidth: longWidthColumnNum !== index + 1 && "150px",
+                }
+              }
             >
               {headElement}
             </Typography>
@@ -78,79 +80,43 @@ export default function CreateGroupTable({
             key={index}
             sx={{
               display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              px: "50px",
               borderTop: index !== 0 && 1,
-              // py: "20px",
               borderColor: "primary.border",
             }}
           >
-            <Box
+            {/* <Box
               sx={{
                 display: "flex",
                 alignItems: "center",
-                flexGrow: 1,
               }}
+            > */}
+            <Select
+              sx={{
+                minWidth: "100px",
+                color: "text.secondary",
+                display: "flex",
+                borderColor: "primary.border",
+              }}
+              defaultValue={10}
             >
-              <Box
-                sx={{
-                  color: "text.secondary",
-                  display: "flex",
-                  flexGrow: 1,
-                  width: "50px",
-                  textOverflow: "ellipsis",
-                  overflowX: "auto",
-                  whiteSpace: "nowrap",
-                  py: "20px",
-                  borderColor: "primary.border",
-                  marginLeft: "55px",
-                }}
-              >
-                {row.name}
-              </Box>
-              <Box
-                sx={{
-                  color: "text.secondary",
-                  display: "flex",
-                  flexGrow: 1,
-                  // width: "50px",
-                  marginLeft: "70px",
-                  textOverflow: "ellipsis",
-                  overflowX: "auto",
-                  whiteSpace: "nowrap",
-                  py: "20px",
-                  borderColor: "primary.border",
-                }}
-              >
-                {row.email}
-              </Box>
-              <Box
-                sx={{
-                  color: "text.secondary",
-                  display: "flex",
-                  flexGrow: 1,
-                  // width: "50px",
-                  marginLeft: "20px",
-                  textOverflow: "ellipsis",
-                  overflowX: "auto",
-                  whiteSpace: "nowrap",
-                  py: "20px",
-                  borderColor: "primary.border",
-                }}
-              >
-                {row.sid}
-              </Box>
+              <MenuItem value={10}>{row.name}</MenuItem>
+              <MenuItem value={20}>{row.sid}</MenuItem>
+              <MenuItem value={30}>{row.email}</MenuItem>
+            </Select>
 
-              <Box
+            {/* <Box
                 sx={{
                   color: "text.secondary",
                   display: "flex",
-                  flexGrow: 1,
-                  marginLeft: "20px",
                   py: "20px",
                   borderColor: "primary.border",
                   gap: "30px",
                 }}
-              >
-                {/* <Select
+              > */}
+            {/* <Select
                   sx={{ width: "170px", color: "text.secondary" }}
                   value={row.courses.length > 0 ? row.courses[0].name : ""}
                 >
@@ -160,56 +126,50 @@ export default function CreateGroupTable({
                     </MenuItem>
                   ))}
                 </Select> */}
-                {row.courses.map((subject, index) => (
-                  <Typography
-                    sx={{
-                      minWidth: "80px",
-                    }}
-                  >
-                    {subject.name} ({subject.prof})
-                  </Typography>
-                ))}
-                {fillThree(row.courses.length).map((subject, index) => (
-                  <Typography
-                    sx={{
-                      minWidth: "80px",
-                    }}
-                  >
-                    {subject}
-                  </Typography>
-                ))}
-              </Box>
-
+            {row.courses.map((subject, index) => (
               <Box
                 sx={{
-                  color: "text.secondary",
-                  display: "flex",
-                  flexGrow: 1,
-                  py: "20px",
-                  ml: "10px",
-                  borderColor: "primary.border",
+                  minWidth: "80px",
                 }}
               >
-                <Select
-                  sx={{ width: "170px", color: "text.secondary" }}
-                  value={row.friends.length > 0 ? row.friends[0].name : ""}
-                >
-                  {row.friends.map((friend, index) => (
-                    <MenuItem key={index} value={friend.name}>
-                      <Typography>
-                        {friend.name}, {friend.sid}
-                      </Typography>
-                    </MenuItem>
-                  ))}
-                </Select>
+                {subject.name} ({subject.prof})
               </Box>
-            </Box>
-            <IconButton
-              onClick={() => handleDeleteRow(row.sid)}
+            ))}
+            {fillThree(row.courses.length).map((subject, index) => (
+              <Box
+                sx={{
+                  minWidth: "80px",
+                }}
+              >
+                {subject}
+              </Box>
+            ))}
+            {/* </Box> */}
+
+            <Box
               sx={{
-                marginRight: "1rem",
+                color: "text.secondary",
+                display: "flex",
+                py: "20px",
+                ml: "10px",
+                borderColor: "primary.border",
               }}
             >
+              <Select
+                sx={{ width: "150px", color: "text.secondary" }}
+                value={row.friends.length > 0 ? row.friends[0].name : ""}
+              >
+                {row.friends.map((friend, index) => (
+                  <MenuItem key={index} value={friend.name}>
+                    <Typography>
+                      {friend.name}, {friend.sid}
+                    </Typography>
+                  </MenuItem>
+                ))}
+              </Select>
+            </Box>
+            {/* </Box> */}
+            <IconButton onClick={() => handleDeleteRow(row.sid)}>
               <Cancel />
             </IconButton>
           </Box>

--- a/histudy-front/src/components/Manager/GroupTables.js
+++ b/histudy-front/src/components/Manager/GroupTables.js
@@ -44,11 +44,12 @@ export default function GroupTables({
   const TableHead = {
     group: [
       "그룹",
-      "멤버",
+      "학생 정보",
       "희망 1과목",
       "희망 2과목",
       "희망 3과목",
       "함께하고 싶은 친구",
+      "수정",
     ],
   };
   const [edit, setEdit] = useState([false]);
@@ -79,9 +80,10 @@ export default function GroupTables({
     <Box>
       <Box
         sx={{
+          minWidth: "1000px",
           maxHeight: "60vh",
           overflow: "scroll",
-          py: "5px",
+          py: "30px",
           border: 1,
           backgroundColor: "primary.default",
           borderColor: "primary.main",
@@ -93,19 +95,14 @@ export default function GroupTables({
           sx={{
             color: "text.secondary",
             display: "flex",
-            py: "20px",
+            justifyContent: "space-between",
+            py: "0px",
             borderColor: "primary.border",
-            px: "30px",
+            px: "50px",
           }}
         >
           {TableHead[type].map((headElement, index) => (
-            <Typography
-              key={index}
-              sx={{
-                flexGrow: 1,
-                minWidth: "150px",
-              }}
-            >
+            <Typography key={index} sx={{}}>
               {headElement}
             </Typography>
           ))}
@@ -138,82 +135,54 @@ export default function GroupTables({
                         sx={{
                           color: "text.secondary",
                           display: "flex",
-                          flexGrow: 4,
+                          alignItems: "center",
+                          justifyContent: "space-between",
+                          gap: "10px",
+                          px: "10px",
+                          borderBottom: 1,
+                          borderColor: "primary.border",
                         }}
                       >
                         <Box
                           key="Group"
                           sx={{
                             color: "text.secondary",
-                            display: "flex",
-                            flexGrow: 1,
-                            width: "150px",
-                            borderBottom: 1,
-                            marginTop: "20px",
+                            width: "50px",
                             py: "20px",
                             borderColor: "primary.border",
                           }}
                         >
                           <Typography>Group{row.tag}</Typography>
                         </Box>
-                        <Box
+                        <Select
                           sx={{
+                            minWidth: "100px",
                             color: "text.secondary",
-                            display: "flex",
-                            flexGrow: 1,
-                            borderBottom: 1,
-                            py: "20px",
-                            marginTop: "20px",
-                            width: "150px",
                             borderColor: "primary.border",
                           }}
+                          defaultValue={10}
                         >
-                          {index > 0 && ", "}
-                          <Typography>{student.name},</Typography>
-                          <Typography>{student.sid}</Typography>
-                        </Box>
+                          <MenuItem value={10}>{student.name}</MenuItem>
+                          <MenuItem value={20}>{student.sid}</MenuItem>
+                          <MenuItem value={30}>{student.email}</MenuItem>
+                        </Select>
                         <Box
                           sx={{
                             color: "text.secondary",
                             display: "flex",
-                            flexGrow: 1,
-                            py: "20px",
-                            borderBottom: 1,
                             borderColor: "primary.border",
                             alignItems: "center",
                             gap: "20px",
                           }}
                         >
-                          {/* <Select
-                            sx={{ width: "170px", color: "text.secondary" }}
-                            value={
-                              student.courses.length > 0
-                                ? student.courses[0].name
-                                : ""
-                            }
-                          >
-                            {student.courses.map((subject, index) => (
-                              <MenuItem key={index} value={subject.name}>
-                                <Typography>{subject.name}</Typography>
-                              </MenuItem>
-                            ))}
-                          </Select> */}
                           {student.courses.map((subject, index) => (
-                            <Typography
-                              sx={{
-                                minWidth: "150px",
-                              }}
-                            >
+                            <Typography sx={{ width: "120px" }}>
                               {subject.name} ({subject.prof})
                             </Typography>
                           ))}
                           {fillThree(student.courses.length).map(
                             (subject, index) => (
-                              <Typography
-                                sx={{
-                                  minWidth: "150px",
-                                }}
-                              >
+                              <Typography sx={{ minWidth: "120px" }}>
                                 {subject}
                               </Typography>
                             )
@@ -223,9 +192,7 @@ export default function GroupTables({
                           sx={{
                             color: "text.secondary",
                             display: "flex",
-                            flexGrow: 1,
                             py: "20px",
-                            borderBottom: 1,
                             borderColor: "primary.border",
                           }}
                         >
@@ -251,7 +218,6 @@ export default function GroupTables({
                             color: "text.secondary",
                             display: "flex",
                             // flexGrow: 1,
-                            borderBottom: 1,
                             borderColor: "primary.border",
                           }}
                         >

--- a/histudy-front/src/components/Manager/StudentListTable.js
+++ b/histudy-front/src/components/Manager/StudentListTable.js
@@ -20,7 +20,6 @@ export default function StudentListTable({
   longWidthColumnNum,
   data,
 }) {
-  console.log("DD", data);
   const { register, getValues, setValue } = useForm({
     initialValues: {
       name: "",
@@ -30,7 +29,18 @@ export default function StudentListTable({
   });
 
   const TableHead = {
-    student: ["이름", "학번", "그룹", "희망과목"],
+    student: [
+      "그룹",
+      "이름",
+      "학번",
+      "",
+      "이메일",
+      "",
+      "",
+      "희망과목",
+      "",
+      "수정",
+    ],
   };
 
   const [edit, setEdit] = useState([false]);
@@ -68,6 +78,7 @@ export default function StudentListTable({
     <>
       <Box
         sx={{
+          minWidth: "1000px",
           py: "5px",
           border: 1,
           backgroundColor: "primary.default",
@@ -82,7 +93,7 @@ export default function StudentListTable({
             color: "text.secondary",
             display: "flex",
             py: "20px",
-
+            justifyContent: "space-between",
             borderColor: "primary.main",
             px: "60px",
           }}
@@ -90,11 +101,11 @@ export default function StudentListTable({
           {TableHead[type].map((headElement, index) => (
             <Typography
               key={index}
-              sx={{
-                flexGrow: 1,
-                width: longWidthColumnNum === index + 1 && "50%",
-                minWidth: longWidthColumnNum !== index + 1 && "150px",
-              }}
+              sx={
+                {
+                  // minWidth: longWidthColumnNum !== index - 3 && "200px",
+                }
+              }
             >
               {headElement}
             </Typography>
@@ -114,21 +125,28 @@ export default function StudentListTable({
                 <Box
                   sx={{
                     display: "flex",
+                    gap: "30px",
+
+                    justifyContent: "space-between",
+                    width: "100%",
                     alignItems: "center",
-                    flexGrow: 1,
+                    px: "50px",
+                    py: "20px",
                   }}
                 >
                   <Box
                     sx={{
                       color: "text.secondary",
                       display: "flex",
-                      flexGrow: 1,
-                      width: "50px",
-                      textOverflow: "ellipsis",
-                      overflowX: "auto",
-                      whiteSpace: "nowrap",
-                      marginLeft: "3rem",
-                      // py: "20px",
+                    }}
+                  >
+                    Group{row.group}
+                  </Box>
+
+                  <Box
+                    sx={{
+                      color: "text.secondary",
+                      display: "flex",
                       borderColor: "primary.border",
                     }}
                   >
@@ -139,12 +157,6 @@ export default function StudentListTable({
                     sx={{
                       color: "text.secondary",
                       display: "flex",
-                      flexGrow: 1,
-                      width: "50px",
-                      textOverflow: "ellipsis",
-                      overflowX: "auto",
-                      whiteSpace: "nowrap",
-                      marginLeft: "5rem",
                       borderColor: "primary.border",
                     }}
                   >
@@ -154,80 +166,38 @@ export default function StudentListTable({
                   <Box
                     sx={{
                       color: "text.secondary",
-                      display: "flex",
-                      flexGrow: 1,
-                      width: "50px",
-                      textOverflow: "ellipsis",
-                      overflowX: "auto",
-                      whiteSpace: "nowrap",
-                      marginLeft: "4rem",
-                      borderColor: "primary.border",
-                    }}
-                  >
-                    Group{row.group}
-                  </Box>
-                  <Box
-                    sx={{
-                      color: "text.secondary",
-                      display: "flex",
-                      flexGrow: 1,
-                      marginLeft: "20px",
-                      py: "20px",
-                      borderColor: "primary.border",
-                    }}
-                  >
-                    <Select
-                      sx={{ width: "170px", color: "text.secondary" }}
-                      value={row.courses.length > 0 ? row.courses[0].name : ""}
-                    >
-                      {row.courses.map((subject, index) => (
-                        <MenuItem key={index} value={subject.name}>
-                          <Typography>
-                            {subject.name} ({subject.prof})
-                          </Typography>
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </Box>
-                </Box>
 
-                <Box
-                  sx={{
-                    color: "text.secondary",
-                    display: "flex",
-                    borderColor: "primary.border",
-                  }}
-                >
-                  <Box
-                    sx={{
-                      color: "text.secondary",
-                      display: "flex",
-                      flexGrow: 1,
-                      alignItems: "center",
-                      justifyContent: "space-between",
+                      width: "250px",
+                      borderColor: "primary.border",
+                      whiteSpace: "normal",
+                      wordWrap: "break-word",
                     }}
                   >
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        marginRight: "20px",
-                      }}
-                    >
-                      <Box sx={{ display: "flex" }}>
-                        <IconButton
-                          onClick={() => {
-                            handleEdit(index);
-                            setValue("name", row.name);
-                            setValue("sid", row.sid);
-                            setValue("team", row.group);
-                          }}
-                        >
-                          <Edit />
-                        </IconButton>
-                      </Box>
-                    </Box>
+                    {row.email}
                   </Box>
+
+                  <Select
+                    sx={{ width: "170px", color: "text.secondary" }}
+                    value={row.courses.length > 0 ? row.courses[0].name : ""}
+                  >
+                    {row.courses.map((subject, index) => (
+                      <MenuItem key={index} value={subject.name}>
+                        <Typography>
+                          {subject.name} ({subject.prof})
+                        </Typography>
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  <IconButton
+                    onClick={() => {
+                      handleEdit(index);
+                      setValue("name", row.name);
+                      setValue("sid", row.sid);
+                      setValue("team", row.group);
+                    }}
+                  >
+                    <Edit />
+                  </IconButton>
                 </Box>
               </Box>
             ) : (

--- a/histudy-front/src/components/Manager/UnGroupTable.js
+++ b/histudy-front/src/components/Manager/UnGroupTable.js
@@ -226,7 +226,7 @@ export default function UnGroupTable({
                     display: "flex",
                     alignItems: "center",
                     flexGrow: 1,
-                    px: "20px",
+                    px: "30px",
                   }}
                 >
                   <Box
@@ -235,7 +235,6 @@ export default function UnGroupTable({
                       display: "flex",
                       flexGrow: 1,
                       borderColor: "primary.border",
-                      mr: "10px",
                     }}
                   >
                     <GroupSelector setTeam={setTeam} />
@@ -243,7 +242,7 @@ export default function UnGroupTable({
 
                   <Select
                     sx={{
-                      minWidth: "100px",
+                      minWidth: "80px",
                       color: "text.secondary",
                       display: "flex",
                       textOverflow: "ellipsis",
@@ -285,7 +284,7 @@ export default function UnGroupTable({
                     {row.courses.map((subject, index) => (
                       <Typography
                         sx={{
-                          minWidth: "120px",
+                          width: "120px",
                         }}
                       >
                         {subject.name} ({subject.prof})
@@ -294,7 +293,7 @@ export default function UnGroupTable({
                     {fillThree(row.courses.length).map((subject, index) => (
                       <Typography
                         sx={{
-                          minWidth: "120px",
+                          width: "120px",
                         }}
                       >
                         {subject}
@@ -314,7 +313,7 @@ export default function UnGroupTable({
                     }}
                   >
                     <Select
-                      sx={{ width: "170px", color: "text.secondary" }}
+                      sx={{ width: "140px", color: "text.secondary" }}
                       value={row.friends.length > 0 ? row.friends[0].name : ""}
                     >
                       {row.friends.map((friend, index) => (

--- a/histudy-front/src/components/Manager/UnGroupTable.js
+++ b/histudy-front/src/components/Manager/UnGroupTable.js
@@ -30,11 +30,12 @@ export default function UnGroupTable({
   const TableHead = {
     group: [
       "그룹",
-      "이름",
+      "학생 정보",
       "희망 1과목",
       "희망 2과목",
       "희망 3과목",
       "함께하고 싶은 친구",
+      "수정",
     ],
   };
 
@@ -78,6 +79,7 @@ export default function UnGroupTable({
           sx={{
             color: "text.secondary",
             display: "flex",
+            justifyContent: "space-between",
             py: "20px",
             borderBottom: 1,
             borderColor: "primary.main",
@@ -87,11 +89,13 @@ export default function UnGroupTable({
           {TableHead[type].map((headElement, index) => (
             <Typography
               key={index}
-              sx={{
-                // flexGrow: 1,
-                // width: longWidthColumnNum === index + 1 && "50%",
-                minWidth: "150px",
-              }}
+              sx={
+                {
+                  // flexGrow: 1,
+                  // width: longWidthColumnNum === index + 1 && "50%",
+                  // minWidth: "150px",
+                }
+              }
             >
               {headElement}
             </Typography>
@@ -104,108 +108,98 @@ export default function UnGroupTable({
                 key={index}
                 sx={{
                   display: "flex",
+                  px: "50px",
+                  justifyContent: "space-between",
                   borderTop: index !== 0 && 1,
-                  // py: "20px",
+                  alignItems: "center",
                   borderColor: "primary.border",
                 }}
               >
                 <Box
                   sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    flexGrow: 1,
+                    color: "text.secondary",
+                    borderColor: "primary.border",
                   }}
                 >
-                  <Box
-                    sx={{
-                      color: "text.secondary",
-                      display: "flex",
-                      flexGrow: 1,
-                      minWidth: "100px",
-                      marginLeft: "50px",
-                      textOverflow: "ellipsis",
-                      overflowX: "auto",
-                      whiteSpace: "nowrap",
-                      // py: "20px",
-                      borderColor: "primary.border",
-                    }}
-                  >
-                    미배정
-                  </Box>
+                  미배정
+                </Box>
 
-                  <Box
+                <Select
+                  sx={{
+                    minWidth: "100px",
+                    color: "text.secondary",
+                    display: "flex",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    borderColor: "primary.border",
+                  }}
+                  defaultValue={10}
+                >
+                  <MenuItem value={10}>{row.name}</MenuItem>
+                  <MenuItem value={20}>{row.sid}</MenuItem>
+                  <MenuItem value={30}>{row.email}</MenuItem>
+                </Select>
+                {/* <Box
                     sx={{
                       color: "text.secondary",
                       display: "flex",
-                      // flexGrow: 1,
-                      width: "150px",
-                      textOverflow: "ellipsis",
-                      // overflowX: "auto",
-                      whiteSpace: "nowrap",
-                      py: "20px",
-                      borderColor: "primary.border",
-                      // justifyContent: "center",
-                    }}
-                  >
-                    {row.name},{row.sid}
-                  </Box>
-
-                  <Box
-                    sx={{
-                      color: "text.secondary",
-                      display: "flex",
+                      
                       flexGrow: 1,
                       marginLeft: "20px",
                       py: "20px",
                       borderColor: "primary.border",
-                      gap: "20px",
+                      // gap: "20px",
                     }}
-                  >
-                    {row.courses.map((subject, index) => (
-                      <Typography
-                        sx={{
-                          minWidth: "150px",
-                        }}
-                      >
-                        {subject.name} ({subject.prof})
-                      </Typography>
-                    ))}
-                    {fillThree(row.courses.length).map((subject, index) => (
-                      <Typography
-                        sx={{
-                          minWidth: "150px",
-                        }}
-                      >
-                        {subject}
-                      </Typography>
-                    ))}
-                  </Box>
-
+                  > */}
+                {row.courses.map((subject, index) => (
                   <Box
-                    sx={{
-                      color: "text.secondary",
-                      display: "flex",
-                      flexGrow: 1,
-                      py: "20px",
-                      borderColor: "primary.border",
-                    }}
+                    sx={
+                      {
+                        // minWidth: "150px",
+                      }
+                    }
                   >
-                    <Select
-                      sx={{ width: "170px", color: "text.secondary" }}
-                      value={row.friends.length > 0 ? row.friends[0].name : ""}
-                    >
-                      {row.friends.map((friend, index) => (
-                        <MenuItem key={index} value={friend.name}>
-                          <Typography>
-                            {friend.name}, {friend.sid}
-                          </Typography>
-                        </MenuItem>
-                      ))}
-                    </Select>
+                    {subject.name} ({subject.prof})
                   </Box>
-                </Box>
+                ))}
+                {fillThree(row.courses.length).map((subject, index) => (
+                  <Box
+                    sx={
+                      {
+                        // minWidth: "80px",
+                      }
+                    }
+                  >
+                    {subject}
+                  </Box>
+                ))}
+                {/* </Box> */}
 
-                <Box sx={{ marginRight: "20px", py: "25px" }}>
+                {/* <Box
+                  sx={{
+                    color: "text.secondary",
+                    display: "flex",
+                    flexGrow: 1,
+                    py: "20px",
+                    borderColor: "primary.border",
+                  }}
+                > */}
+                <Select
+                  sx={{ color: "text.secondary", width: "150px" }}
+                  value={row.friends.length > 0 ? row.friends[0].name : ""}
+                >
+                  {row.friends.map((friend, index) => (
+                    <MenuItem key={index} value={friend.name}>
+                      <Typography>
+                        {friend.name}, {friend.sid}
+                      </Typography>
+                    </MenuItem>
+                  ))}
+                </Select>
+                {/* </Box> */}
+                {/* </Box> */}
+
+                <Box sx={{ py: "25px" }}>
                   <IconButton
                     onClick={() => {
                       handleEdit(index);
@@ -233,6 +227,7 @@ export default function UnGroupTable({
                     display: "flex",
                     alignItems: "center",
                     flexGrow: 1,
+                    px: "20px",
                   }}
                 >
                   <Box
@@ -240,45 +235,29 @@ export default function UnGroupTable({
                       color: "text.secondary",
                       display: "flex",
                       flexGrow: 1,
-                      marginLeft: "20px",
-                      textOverflow: "ellipsis",
-                      overflowX: "auto",
-                      whiteSpace: "nowrap",
                       borderColor: "primary.border",
+                      mr: "10px",
                     }}
                   >
                     <GroupSelector setTeam={setTeam} />
                   </Box>
 
-                  <Box
+                  <Select
                     sx={{
+                      minWidth: "100px",
                       color: "text.secondary",
                       display: "flex",
-                      flexGrow: 1,
-                      width: "120px",
-                      marginLeft: "50px",
-
                       textOverflow: "ellipsis",
-                      overflowX: "auto",
                       whiteSpace: "nowrap",
-                      // py: "20px",
+
                       borderColor: "primary.border",
                     }}
+                    defaultValue={10}
                   >
-                    {row.name},
-                    <TextField
-                      sx={{
-                        width: "100px",
-                        "& input": {
-                          height: "10px",
-                        },
-                      }}
-                      defaultValue={row.sid}
-                      onChange={(e) => {
-                        setSid(e.target.value);
-                      }}
-                    ></TextField>
-                  </Box>
+                    <MenuItem value={10}>{row.name}</MenuItem>
+                    <MenuItem value={20}>{row.sid}</MenuItem>
+                    <MenuItem value={30}>{row.email}</MenuItem>
+                  </Select>
 
                   <Box
                     sx={{

--- a/histudy-front/src/components/Manager/UnGroupTable.js
+++ b/histudy-front/src/components/Manager/UnGroupTable.js
@@ -65,7 +65,9 @@ export default function UnGroupTable({
     <>
       <Box
         sx={{
+          minWidth: "1000px",
           maxHeight: "60vh",
+
           overflow: "scroll",
           py: "5px",
           border: 1,
@@ -83,7 +85,7 @@ export default function UnGroupTable({
             py: "20px",
             borderBottom: 1,
             borderColor: "primary.main",
-            px: "60px",
+            px: "50px",
           }}
         >
           {TableHead[type].map((headElement, index) => (
@@ -109,6 +111,7 @@ export default function UnGroupTable({
                 sx={{
                   display: "flex",
                   px: "50px",
+                  gap: "10px",
                   justifyContent: "space-between",
                   borderTop: index !== 0 && 1,
                   alignItems: "center",
@@ -153,22 +156,18 @@ export default function UnGroupTable({
                   > */}
                 {row.courses.map((subject, index) => (
                   <Box
-                    sx={
-                      {
-                        // minWidth: "150px",
-                      }
-                    }
+                    sx={{
+                      width: "120px",
+                    }}
                   >
                     {subject.name} ({subject.prof})
                   </Box>
                 ))}
                 {fillThree(row.courses.length).map((subject, index) => (
                   <Box
-                    sx={
-                      {
-                        // minWidth: "80px",
-                      }
-                    }
+                    sx={{
+                      width: "120px",
+                    }}
                   >
                     {subject}
                   </Box>
@@ -286,7 +285,7 @@ export default function UnGroupTable({
                     {row.courses.map((subject, index) => (
                       <Typography
                         sx={{
-                          minWidth: "150px",
+                          minWidth: "120px",
                         }}
                       >
                         {subject.name} ({subject.prof})
@@ -295,7 +294,7 @@ export default function UnGroupTable({
                     {fillThree(row.courses.length).map((subject, index) => (
                       <Typography
                         sx={{
-                          minWidth: "150px",
+                          minWidth: "120px",
                         }}
                       >
                         {subject}

--- a/histudy-front/src/pages/Manager/ManageStudent.js
+++ b/histudy-front/src/pages/Manager/ManageStudent.js
@@ -58,7 +58,8 @@ export default function ManageStudent() {
     sheetData = studentData.map((student) => ({
       ID: student.id,
       Name: student.name,
-      Number: student.sid,
+      StudentId: student.sid,
+      Email: student.email,
       Group: student.group,
       Courses: student.courses
         .map((subject) => subject.name + `(${subject.prof})`)
@@ -135,7 +136,7 @@ export default function ManageStudent() {
               <StudentListTable
                 data={searchResult}
                 accentColumnNum={-1}
-                longWidthColumnNum={-1}
+                longWidthColumnNum={3}
                 type="student"
               />
             )}


### PR DESCRIPTION
Request Description
신청자 목록에, 학생들 이메일 주소가 나오면 좋겠어요 스터디 하는 학생들에게 일괄 메일 보낼 때 필요합니다.

백앤드 작업
/api/admin/manageGroup
/api/admin/unmatched-users
/api/admin/allUsers
/api/admin/users/unassigned

네 가지 api에서 학생들의 정보를 보내 줄 때 학생의 이메일을 추가해줘서 보내줘야 한다.

프론트앤드 작업
관리자 페이지 중
스터디 그룹 생성
그룹 매칭 관리
스터디 신청자 정보 관리
페이지에서 학생들의 이메일 정보를 추가로 보여준다.
그리고 엑셀 다운로드에서 학생 이메일 정보를 추가로 출력해준다.

Reference Issue
https://github.com/HGU-WALAB/histudy-be/issues/141 #79