### PR TITLE
fix(reports): guard oversized report image uploads

### DIFF
--- a/src/pages/ReportAdd/Page.tsx
+++ b/src/pages/ReportAdd/Page.tsx
@@ -177,23 +177,20 @@ export default function ReportAddPage() {
       }
 
       try {
-         const imageServerUploadPromises = formData.blobImages.map((file, i) => {
-            return new Promise<string>((resolve, reject) => {
-               setTimeout(async () => {
-                  const fd = new FormData();
-                  fd.append('image', file);
+         const results: string[] = [];
 
-                  try {
-                     const res = await ImageUploadToServer(null, fd);
-                     resolve(res.data.imagePath);
-                  } catch (error) {
-                     reject(error);
-                  }
-               }, 1000 * i);
-            });
-         });
+         for (const [index, file] of formData.blobImages.entries()) {
+            if (index > 0) {
+               await new Promise((resolve) => setTimeout(resolve, 1000));
+            }
 
-         const results = await Promise.all(imageServerUploadPromises);
+            const fd = new FormData();
+            fd.append('image', file);
+
+            const res = await ImageUploadToServer(null, fd);
+            results.push(res.data.imagePath);
+         }
+
          form.setValue('images', results);
       } catch (error) {
          const errorMessage = isReportImageUploadTooLargeError(error)

--- a/src/pages/ReportAdd/Page.tsx
+++ b/src/pages/ReportAdd/Page.tsx
@@ -18,10 +18,12 @@ import { NewReport } from '@/interface/report';
 import { StudyCertificationDialog } from '@/pages/ReportAdd/components/StudyCertificationDialog';
 import {
    REPORT_CONTENT_MAX_LENGTH,
+   REPORT_IMAGE_UPLOAD_FAILURE_MESSAGE,
    REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES,
    REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE,
    getReportContentCharacterCount,
    isReportImageFileSizeExceeded,
+   isReportImageUploadTooLargeError,
 } from '@/utils/reportForm';
 import Heic2Jpg from '@/utils/Heic2Jpg';
 import { convertBlobToWebp } from '@/utils/convertBlobToWebp';
@@ -174,24 +176,33 @@ export default function ReportAddPage() {
          return;
       }
 
-      const imageServerUploadPromises = formData.blobImages.map((file, i) => {
-         return new Promise((resolve) => {
-            setTimeout(async () => {
-               const fd = new FormData();
-               fd.append('image', file);
+      try {
+         const imageServerUploadPromises = formData.blobImages.map((file, i) => {
+            return new Promise<string>((resolve, reject) => {
+               setTimeout(async () => {
+                  const fd = new FormData();
+                  fd.append('image', file);
 
-               try {
-                  const res = await ImageUploadToServer(null, fd);
-                  resolve(res.data.imagePath);
-               } catch (error) {
-                  resolve(null);
-               }
-            }, 1000 * i);
+                  try {
+                     const res = await ImageUploadToServer(null, fd);
+                     resolve(res.data.imagePath);
+                  } catch (error) {
+                     reject(error);
+                  }
+               }, 1000 * i);
+            });
          });
-      });
 
-      const results = await Promise.all(imageServerUploadPromises);
-      form.setValue('images', results.filter((path) => path !== null) as string[]);
+         const results = await Promise.all(imageServerUploadPromises);
+         form.setValue('images', results);
+      } catch (error) {
+         const errorMessage = isReportImageUploadTooLargeError(error)
+            ? REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE
+            : REPORT_IMAGE_UPLOAD_FAILURE_MESSAGE;
+         setImageUploadError(errorMessage);
+         toast.error(errorMessage);
+         return;
+      }
 
       // 보고서 생성 api 연결
       const newReport = {

--- a/src/pages/ReportAdd/Page.tsx
+++ b/src/pages/ReportAdd/Page.tsx
@@ -16,7 +16,13 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { paths } from '@/const/paths';
 import { NewReport } from '@/interface/report';
 import { StudyCertificationDialog } from '@/pages/ReportAdd/components/StudyCertificationDialog';
-import { REPORT_CONTENT_MAX_LENGTH, REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES, getReportContentCharacterCount } from '@/utils/reportForm';
+import {
+   REPORT_CONTENT_MAX_LENGTH,
+   REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES,
+   REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE,
+   getReportContentCharacterCount,
+   isReportImageFileSizeExceeded,
+} from '@/utils/reportForm';
 import Heic2Jpg from '@/utils/Heic2Jpg';
 import { convertBlobToWebp } from '@/utils/convertBlobToWebp';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -162,6 +168,12 @@ export default function ReportAddPage() {
    const [previewImages, blobImages] = form.watch(['previewImages', 'blobImages']);
 
    const onValid = async (formData: ReportFormState) => {
+      if (formData.blobImages.some(isReportImageFileSizeExceeded)) {
+         setImageUploadError(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
+         toast.error(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
+         return;
+      }
+
       const imageServerUploadPromises = formData.blobImages.map((file, i) => {
          return new Promise((resolve) => {
             setTimeout(async () => {
@@ -249,8 +261,8 @@ export default function ReportAddPage() {
       const targetFile = file[0];
 
       if (targetFile.size > REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES) {
-         setImageUploadError('이미지는 파일당 5MB 이하만 업로드할 수 있습니다.');
-         toast.error('이미지는 파일당 5MB 이하만 업로드할 수 있습니다.');
+         setImageUploadError(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
+         toast.error(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
          e.target.value = '';
          return;
       }
@@ -264,6 +276,13 @@ export default function ReportAddPage() {
          targetBlob = await convertBlobToWebp(targetBlob);
       } else {
          targetBlob = await convertBlobToWebp(targetFile);
+      }
+
+      if (isReportImageFileSizeExceeded(targetBlob)) {
+         setImageUploadError(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
+         toast.error(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
+         e.target.value = '';
+         return;
       }
 
       const reader = new FileReader();

--- a/src/pages/ReportEdit/Page.tsx
+++ b/src/pages/ReportEdit/Page.tsx
@@ -20,10 +20,12 @@ import { NewReport } from '@/interface/report';
 import { StudyCertificationDialog } from '@/pages/ReportAdd/components/StudyCertificationDialog';
 import {
    REPORT_CONTENT_MAX_LENGTH,
+   REPORT_IMAGE_UPLOAD_FAILURE_MESSAGE,
    REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES,
    REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE,
    getReportContentCharacterCount,
    isReportImageFileSizeExceeded,
+   isReportImageUploadTooLargeError,
 } from '@/utils/reportForm';
 import Heic2Jpg from '@/utils/Heic2Jpg';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -193,24 +195,34 @@ export default function ReportEditPage() {
          return;
       }
 
-      const imageServerUploadPromises = formData.blobImages.map((file, i) => {
-         return new Promise((resolve) => {
-            setTimeout(async () => {
-               const fd = new FormData();
-               fd.append('image', file);
+      let newImagePaths: string[];
 
-               try {
-                  const res = await ImageUploadToServer(+id, fd);
-                  resolve(res.data.imagePath);
-               } catch (error) {
-                  resolve(null);
-               }
-            }, 1000 * i);
+      try {
+         const imageServerUploadPromises = formData.blobImages.map((file, i) => {
+            return new Promise<string>((resolve, reject) => {
+               setTimeout(async () => {
+                  const fd = new FormData();
+                  fd.append('image', file);
+
+                  try {
+                     const res = await ImageUploadToServer(+id, fd);
+                     resolve(res.data.imagePath);
+                  } catch (error) {
+                     reject(error);
+                  }
+               }, 1000 * i);
+            });
          });
-      });
 
-      const results = await Promise.all(imageServerUploadPromises);
-      const newImagePaths = results.filter((path) => path !== null) as string[];
+         newImagePaths = await Promise.all(imageServerUploadPromises);
+      } catch (error) {
+         const errorMessage = isReportImageUploadTooLargeError(error)
+            ? REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE
+            : REPORT_IMAGE_UPLOAD_FAILURE_MESSAGE;
+         setImageUploadError(errorMessage);
+         toast.error(errorMessage);
+         return;
+      }
 
       // 기존 이미지와 새 이미지 합치기
       const existingImages = form.getValues('images');

--- a/src/pages/ReportEdit/Page.tsx
+++ b/src/pages/ReportEdit/Page.tsx
@@ -18,7 +18,13 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { paths } from '@/const/paths';
 import { NewReport } from '@/interface/report';
 import { StudyCertificationDialog } from '@/pages/ReportAdd/components/StudyCertificationDialog';
-import { REPORT_CONTENT_MAX_LENGTH, REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES, getReportContentCharacterCount } from '@/utils/reportForm';
+import {
+   REPORT_CONTENT_MAX_LENGTH,
+   REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES,
+   REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE,
+   getReportContentCharacterCount,
+   isReportImageFileSizeExceeded,
+} from '@/utils/reportForm';
 import Heic2Jpg from '@/utils/Heic2Jpg';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -181,6 +187,12 @@ export default function ReportEditPage() {
    const [previewImages, blobImages] = form.watch(['previewImages', 'blobImages']);
 
    const onValid = async (formData: ReportFormState) => {
+      if (formData.blobImages.some(isReportImageFileSizeExceeded)) {
+         setImageUploadError(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
+         toast.error(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
+         return;
+      }
+
       const imageServerUploadPromises = formData.blobImages.map((file, i) => {
          return new Promise((resolve) => {
             setTimeout(async () => {
@@ -271,8 +283,8 @@ export default function ReportEditPage() {
       const targetFile = file[0];
 
       if (targetFile.size > REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES) {
-         setImageUploadError('이미지는 파일당 5MB 이하만 업로드할 수 있습니다.');
-         toast.error('이미지는 파일당 5MB 이하만 업로드할 수 있습니다.');
+         setImageUploadError(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
+         toast.error(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
          e.target.value = '';
          return;
       }
@@ -286,6 +298,13 @@ export default function ReportEditPage() {
          targetBlob = await convertBlobToWebp(targetBlob);
       } else {
          targetBlob = await convertBlobToWebp(targetFile);
+      }
+
+      if (isReportImageFileSizeExceeded(targetBlob)) {
+         setImageUploadError(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
+         toast.error(REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE);
+         e.target.value = '';
+         return;
       }
 
       const reader = new FileReader();

--- a/src/pages/ReportEdit/Page.tsx
+++ b/src/pages/ReportEdit/Page.tsx
@@ -195,26 +195,20 @@ export default function ReportEditPage() {
          return;
       }
 
-      let newImagePaths: string[];
+      const newImagePaths: string[] = [];
 
       try {
-         const imageServerUploadPromises = formData.blobImages.map((file, i) => {
-            return new Promise<string>((resolve, reject) => {
-               setTimeout(async () => {
-                  const fd = new FormData();
-                  fd.append('image', file);
+         for (const [index, file] of formData.blobImages.entries()) {
+            if (index > 0) {
+               await new Promise((resolve) => setTimeout(resolve, 1000));
+            }
 
-                  try {
-                     const res = await ImageUploadToServer(+id, fd);
-                     resolve(res.data.imagePath);
-                  } catch (error) {
-                     reject(error);
-                  }
-               }, 1000 * i);
-            });
-         });
+            const fd = new FormData();
+            fd.append('image', file);
 
-         newImagePaths = await Promise.all(imageServerUploadPromises);
+            const res = await ImageUploadToServer(+id, fd);
+            newImagePaths.push(res.data.imagePath);
+         }
       } catch (error) {
          const errorMessage = isReportImageUploadTooLargeError(error)
             ? REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE

--- a/src/utils/reportForm.ts
+++ b/src/utils/reportForm.ts
@@ -1,6 +1,9 @@
+import axios from 'axios';
+
 export const REPORT_CONTENT_MAX_LENGTH = 1000;
 export const REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES = 5 * 1024 * 1024;
 export const REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE = '이미지는 파일당 5MB 이하만 업로드할 수 있습니다.';
+export const REPORT_IMAGE_UPLOAD_FAILURE_MESSAGE = '이미지 업로드에 실패했습니다. 다시 시도해주세요.';
 
 const BLOCK_TAG_NAMES = new Set([
    'ADDRESS',
@@ -97,4 +100,8 @@ export function getReportContentCharacterCount(html: string): number {
 
 export function isReportImageFileSizeExceeded(file: Blob): boolean {
    return file.size > REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES;
+}
+
+export function isReportImageUploadTooLargeError(error: unknown): boolean {
+   return axios.isAxiosError(error) && error.response?.status === 413;
 }

--- a/src/utils/reportForm.ts
+++ b/src/utils/reportForm.ts
@@ -1,5 +1,6 @@
 export const REPORT_CONTENT_MAX_LENGTH = 1000;
 export const REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES = 5 * 1024 * 1024;
+export const REPORT_IMAGE_UPLOAD_MAX_SIZE_MESSAGE = '이미지는 파일당 5MB 이하만 업로드할 수 있습니다.';
 
 const BLOCK_TAG_NAMES = new Set([
    'ADDRESS',
@@ -92,4 +93,8 @@ export function getReportContentCharacterCount(html: string): number {
    const text = Array.from(template.content.childNodes).map(getNodeText).join('');
 
    return text.endsWith('\n') ? text.slice(0, -1).length : text.length;
+}
+
+export function isReportImageFileSizeExceeded(file: Blob): boolean {
+   return file.size > REPORT_IMAGE_UPLOAD_MAX_SIZE_BYTES;
 }

--- a/tests/reports/report.member.spec.ts
+++ b/tests/reports/report.member.spec.ts
@@ -220,15 +220,27 @@ test.describe('스터디원 리포트 테스트', () => {
 
          await chooseFirstCourseAndFriend(page);
          await fillReportForm(page, draft);
+         const unexpectedUploadRequest = waitForUnexpectedImageUploadRequest(page);
          await page.getByRole('button', { name: '제출' }).click();
 
          await expect(
             page.locator('p.text-sm.text-destructive').filter({ hasText: '이미지는 파일당 5MB 이하만 업로드할 수 있습니다.' }),
          ).toBeVisible();
-         await expect(await waitForUnexpectedImageUploadRequest(page)).toBeNull();
+         await expect(await unexpectedUploadRequest).toBeNull();
          await expect(page).toHaveURL(new RegExp(`${paths.reports.add}$`));
          await expect(reportTitleCell(page, draft.title)).toHaveCount(0);
       });
+   });
+
+   test('파일 선택 시 5MB를 초과하는 이미지는 업로드되지 않는다', async ({ page }) => {
+      await page.goto(paths.reports.add);
+
+      await page.locator('#image-upload').setInputFiles(path.join(imageDirPath, 'test_7MB.jpg'));
+
+      await expect(
+         page.locator('p.text-sm.text-destructive').filter({ hasText: '이미지는 파일당 5MB 이하만 업로드할 수 있습니다.' }),
+      ).toBeVisible();
+      await expect(page.locator('img[alt^="새 이미지"]')).toHaveCount(0);
    });
 
    test('제출 후 이미지 업로드 API가 413을 반환하면 사용자에게 용량 초과 메시지를 보여준다', async ({ page }) => {

--- a/tests/reports/report.member.spec.ts
+++ b/tests/reports/report.member.spec.ts
@@ -79,6 +79,18 @@ async function forceBlobSizeToExceedLimitOnSubmit(page: Page) {
    });
 }
 
+async function mockReportImageUpload413(page: Page) {
+   await page.route('**/api/team/reports/image', async (route) => {
+      await route.fulfill({
+         status: 413,
+         contentType: 'application/json',
+         body: JSON.stringify({
+            code: 'REPORT_IMAGE_TOO_LARGE',
+         }),
+      });
+   });
+}
+
 function reportTitleCell(page: Page, title: string) {
    return page.getByRole('cell', { name: title, exact: true }).first();
 }
@@ -214,6 +226,34 @@ test.describe('스터디원 리포트 테스트', () => {
             page.locator('p.text-sm.text-destructive').filter({ hasText: '이미지는 파일당 5MB 이하만 업로드할 수 있습니다.' }),
          ).toBeVisible();
          await expect(await waitForUnexpectedImageUploadRequest(page)).toBeNull();
+         await expect(page).toHaveURL(new RegExp(`${paths.reports.add}$`));
+         await expect(reportTitleCell(page, draft.title)).toHaveCount(0);
+      });
+   });
+
+   test('제출 후 이미지 업로드 API가 413을 반환하면 사용자에게 용량 초과 메시지를 보여준다', async ({ page }) => {
+      const draft: ReportDraft = {
+         title: `테스트 보고서 제목3-${Date.now()}`,
+         content: '테스트 보고서 내용3',
+         totalMinutes: '62',
+      };
+
+      await test.step('서버 413 응답을 받으면 보고서 저장 없이 같은 메시지로 안내한다', async () => {
+         await page.goto(paths.reports.add);
+
+         await page.getByRole('button', { name: '인증 코드 생성' }).click();
+         await page.getByRole('button', { name: 'Close' }).click();
+
+         await uploadReportImage(page, 'test_png.png', 1);
+         await chooseFirstCourseAndFriend(page);
+         await fillReportForm(page, draft);
+
+         await mockReportImageUpload413(page);
+         await page.getByRole('button', { name: '제출' }).click();
+
+         await expect(
+            page.locator('p.text-sm.text-destructive').filter({ hasText: '이미지는 파일당 5MB 이하만 업로드할 수 있습니다.' }),
+         ).toBeVisible();
          await expect(page).toHaveURL(new RegExp(`${paths.reports.add}$`));
          await expect(reportTitleCell(page, draft.title)).toHaveCount(0);
       });

--- a/tests/reports/report.member.spec.ts
+++ b/tests/reports/report.member.spec.ts
@@ -47,6 +47,38 @@ async function uploadReportImage(page: Page, fileName: string, expectedCount: nu
    await expect(page.locator('img[alt^="새 이미지"]')).toHaveCount(expectedCount, { timeout: 10000 });
 }
 
+async function waitForUnexpectedImageUploadRequest(page: Page, timeout = 1500) {
+   try {
+      return await page.waitForRequest(
+         (request) => {
+            const url = request.url();
+            return request.method() === 'POST' && url.includes('/api/team/reports/image');
+         },
+         { timeout },
+      );
+   } catch {
+      return null;
+   }
+}
+
+async function forceBlobSizeToExceedLimitOnSubmit(page: Page) {
+   await page.evaluate(() => {
+      const descriptor = Object.getOwnPropertyDescriptor(Blob.prototype, 'size');
+      const originalGetter = descriptor?.get;
+
+      if (!originalGetter) {
+         throw new Error('Blob.size getter를 찾을 수 없습니다.');
+      }
+
+      Object.defineProperty(Blob.prototype, 'size', {
+         configurable: true,
+         get() {
+            return 6 * 1024 * 1024;
+         },
+      });
+   });
+}
+
 function reportTitleCell(page: Page, title: string) {
    return page.getByRole('cell', { name: title, exact: true }).first();
 }
@@ -156,39 +188,34 @@ test.describe('스터디원 리포트 테스트', () => {
       });
    });
 
-   test('5MB 초과 이미지는 차단되고 이후 정상 이미지 1장으로 리포트를 작성 및 삭제할 수 있다', async ({ page }) => {
+   test('제출 시점에 최종 업로드 파일이 5MB를 초과하면 업로드 API 호출 없이 차단된다', async ({ page }) => {
       const draft: ReportDraft = {
          title: `테스트 보고서 제목2-${Date.now()}`,
          content: '테스트 보고서 내용2',
          totalMinutes: '61',
       };
-      let studyInfo: SelectedStudyInfo;
 
-      await test.step('초과 용량 업로드를 차단한 뒤 정상 이미지로 리포트를 작성한다', async () => {
+      await test.step('업로드 단계는 통과하지만 제출 직전 최종 파일 크기 검사에서 차단된다', async () => {
          await page.goto(paths.reports.add);
 
          await page.getByRole('button', { name: '인증 코드 생성' }).click();
          await page.getByRole('button', { name: 'Close' }).click();
 
-         await page.locator('#image-upload').setInputFiles(path.join(imageDirPath, 'test_7MB.jpg'));
+         await uploadReportImage(page, 'test_png.png', 1);
+         await expect(page.locator('p.text-sm.text-destructive')).toHaveCount(0);
+
+         await forceBlobSizeToExceedLimitOnSubmit(page);
+
+         await chooseFirstCourseAndFriend(page);
+         await fillReportForm(page, draft);
+         await page.getByRole('button', { name: '제출' }).click();
+
          await expect(
             page.locator('p.text-sm.text-destructive').filter({ hasText: '이미지는 파일당 5MB 이하만 업로드할 수 있습니다.' }),
          ).toBeVisible();
-         await expect(page.locator('img[alt^="새 이미지"]')).toHaveCount(0);
-
-         await uploadReportImage(page, 'test_png.png', 1);
-         studyInfo = await chooseFirstCourseAndFriend(page);
-         await fillReportForm(page, draft);
-         await page.getByRole('button', { name: '제출' }).click();
-         await openReportDetailFromList(page, draft.title);
-         await expectReportDetail(page, draft, studyInfo, 1);
-      });
-
-      await test.step('작성한 리포트를 삭제하고 목록에서 제거되었는지 확인한다', async () => {
-         await page.goto(paths.reports.root);
-         await openReportDetailFromList(page, draft.title);
-         await expectReportDetail(page, draft, studyInfo, 1);
-         await deleteReportAndExpectRemoved(page, draft.title);
+         await expect(await waitForUnexpectedImageUploadRequest(page)).toBeNull();
+         await expect(page).toHaveURL(new RegExp(`${paths.reports.add}$`));
+         await expect(reportTitleCell(page, draft.title)).toHaveCount(0);
       });
    });
 


### PR DESCRIPTION
- 보고서 이미지의 최종 업로드 파일 크기를 제출 직전에도 검증하도록 보강했습니다.
  > 기존에는 파일 선택 시점의 원본 크기만 검사해서 변환 이후 실제 업로드 payload가 서버 제한을 넘는 경우를 완전히 막지 못했습니다. 이번 변경으로 작성과 수정 화면 모두에서 최종 업로드 대상 파일을 다시 확인해 서버 요청 전에 차단합니다. 클라이언트 검증 기준을 실제 업로드 대상과 맞춰 프로덕션에서 발생할 수 있는 용량 초과 누락을 줄이려는 목적입니다.

- 이미지 업로드 API가 413을 반환할 때 사용자에게 동일한 용량 초과 피드백을 주고 제출을 중단하도록 처리했습니다.
  > 서버사이드 제한은 최종 안전망이기 때문에 클라이언트 검증만으로는 충분하지 않습니다. 이제 서버가 413으로 거절한 경우에도 사용자는 같은 메시지로 즉시 원인을 알 수 있고, 업로드 실패 상태에서 보고서가 부분 저장되지 않도록 제출 흐름을 멈춥니다. 관련 E2E 테스트도 함께 보강해 클라이언트 최종 차단과 서버 413 응답 경로를 모두 검증합니다.
